### PR TITLE
FDI-33 Reportes creation

### DIFF
--- a/config/sync/core.base_field_override.node.reporte.promote.yml
+++ b/config/sync/core.base_field_override.node.reporte.promote.yml
@@ -1,0 +1,22 @@
+uuid: f116e3fd-cad3-48bc-806e-2bc6524ae299
+langcode: es
+status: true
+dependencies:
+  config:
+    - node.type.reporte
+id: node.reporte.promote
+field_name: promote
+entity_type: node
+bundle: reporte
+label: 'Promocionado a la página principal'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: Activado
+  off_label: Desactivado
+field_type: boolean

--- a/config/sync/core.base_field_override.node.reporte.title.yml
+++ b/config/sync/core.base_field_override.node.reporte.title.yml
@@ -1,0 +1,18 @@
+uuid: 0b63522a-fe92-4610-9287-67e87513adf8
+langcode: es
+status: true
+dependencies:
+  config:
+    - node.type.reporte
+id: node.reporte.title
+field_name: title
+entity_type: node
+bundle: reporte
+label: Nombre
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/core.entity_form_display.node.reporte.default.yml
+++ b/config/sync/core.entity_form_display.node.reporte.default.yml
@@ -1,0 +1,103 @@
+uuid: 23496401-9166-4097-9729-43fdfb8494e3
+langcode: es
+status: true
+dependencies:
+  config:
+    - field.field.node.reporte.body
+    - field.field.node.reporte.field_categoria_reporte
+    - field.field.node.reporte.field_codigo_de_seguimient
+    - field.field.node.reporte.field_correo
+    - field.field.node.reporte.field_latitud
+    - field.field.node.reporte.field_longitud
+    - field.field.node.reporte.field_lugar
+    - field.field.node.reporte.field_solicita_asesoria_o_apoyo
+    - field.field.node.reporte.field_subcategoria_reporte
+    - node.type.reporte
+  module:
+    - text
+id: node.reporte.default
+targetEntityType: node
+bundle: reporte
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 121
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+    region: content
+  field_categoria_reporte:
+    weight: 122
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
+  field_codigo_de_seguimient:
+    weight: 129
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_correo:
+    weight: 128
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: email_default
+    region: content
+  field_latitud:
+    weight: 125
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+    type: number
+    region: content
+  field_longitud:
+    weight: 126
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+    type: number
+    region: content
+  field_lugar:
+    weight: 124
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textarea
+    region: content
+  field_solicita_asesoria_o_apoyo:
+    weight: 127
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  field_subcategoria_reporte:
+    weight: 123
+    settings: {  }
+    third_party_settings: {  }
+    type: options_buttons
+    region: content
+  title:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden:
+  created: true
+  langcode: true
+  path: true
+  promote: true
+  status: true
+  sticky: true
+  uid: true

--- a/config/sync/core.entity_view_display.node.reporte.default.yml
+++ b/config/sync/core.entity_view_display.node.reporte.default.yml
@@ -1,0 +1,101 @@
+uuid: 163f399d-7862-46d9-880c-3ec196212997
+langcode: es
+status: true
+dependencies:
+  config:
+    - field.field.node.reporte.body
+    - field.field.node.reporte.field_categoria_reporte
+    - field.field.node.reporte.field_codigo_de_seguimient
+    - field.field.node.reporte.field_correo
+    - field.field.node.reporte.field_latitud
+    - field.field.node.reporte.field_longitud
+    - field.field.node.reporte.field_lugar
+    - field.field.node.reporte.field_solicita_asesoria_o_apoyo
+    - field.field.node.reporte.field_subcategoria_reporte
+    - node.type.reporte
+  module:
+    - options
+    - text
+    - user
+id: node.reporte.default
+targetEntityType: node
+bundle: reporte
+mode: default
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 101
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  field_categoria_reporte:
+    weight: 102
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_codigo_de_seguimient:
+    weight: 109
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_correo:
+    weight: 108
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+  field_latitud:
+    weight: 105
+    label: above
+    settings:
+      thousand_separator: ''
+      decimal_separator: .
+      scale: 2
+      prefix_suffix: true
+    third_party_settings: {  }
+    type: number_decimal
+    region: content
+  field_longitud:
+    weight: 106
+    label: above
+    settings:
+      thousand_separator: ''
+      decimal_separator: .
+      scale: 2
+      prefix_suffix: true
+    third_party_settings: {  }
+    type: number_decimal
+    region: content
+  field_lugar:
+    weight: 104
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
+    region: content
+  field_solicita_asesoria_o_apoyo:
+    weight: 107
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
+    region: content
+  field_subcategoria_reporte:
+    weight: 103
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+hidden:
+  langcode: true
+  links: true

--- a/config/sync/core.entity_view_display.node.reporte.default.yml
+++ b/config/sync/core.entity_view_display.node.reporte.default.yml
@@ -33,7 +33,7 @@ content:
     weight: 102
     label: above
     settings:
-      link: true
+      link: false
     third_party_settings: {  }
     type: entity_reference_label
     region: content
@@ -92,7 +92,7 @@ content:
     weight: 103
     label: above
     settings:
-      link: true
+      link: false
     third_party_settings: {  }
     type: entity_reference_label
     region: content

--- a/config/sync/core.entity_view_display.node.reporte.teaser.yml
+++ b/config/sync/core.entity_view_display.node.reporte.teaser.yml
@@ -1,0 +1,29 @@
+uuid: 8914f67a-facb-413b-83bd-db6a37192474
+langcode: es
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.reporte.body
+    - node.type.reporte
+  module:
+    - text
+    - user
+id: node.reporte.teaser
+targetEntityType: node
+bundle: reporte
+mode: teaser
+content:
+  body:
+    label: hidden
+    type: text_summary_or_trimmed
+    weight: 101
+    settings:
+      trim_length: 600
+    third_party_settings: {  }
+    region: content
+  links:
+    weight: 100
+    region: content
+hidden:
+  langcode: true

--- a/config/sync/field.field.node.reporte.body.yml
+++ b/config/sync/field.field.node.reporte.body.yml
@@ -1,0 +1,22 @@
+uuid: c8f207c8-a37e-4b36-9b21-cb4f04cbe929
+langcode: es
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.reporte
+  module:
+    - text
+id: node.reporte.body
+field_name: body
+entity_type: node
+bundle: reporte
+label: Reporte
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: true
+field_type: text_with_summary

--- a/config/sync/field.field.node.reporte.field_categoria_reporte.yml
+++ b/config/sync/field.field.node.reporte.field_categoria_reporte.yml
@@ -1,0 +1,29 @@
+uuid: 34509bf7-c467-45c6-a55c-3c1e3e71de41
+langcode: es
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_categoria_reporte
+    - node.type.reporte
+    - taxonomy.vocabulary.categorias_de_reporte
+id: node.reporte.field_categoria_reporte
+field_name: field_categoria_reporte
+entity_type: node
+bundle: reporte
+label: Categoría
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      categorias_de_reporte: categorias_de_reporte
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.field.node.reporte.field_codigo_de_seguimient.yml
+++ b/config/sync/field.field.node.reporte.field_codigo_de_seguimient.yml
@@ -1,0 +1,19 @@
+uuid: fe39854b-d827-4d9a-a714-768e418bc3b9
+langcode: es
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_codigo_de_seguimient
+    - node.type.reporte
+id: node.reporte.field_codigo_de_seguimient
+field_name: field_codigo_de_seguimient
+entity_type: node
+bundle: reporte
+label: 'Código de seguimiento'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.reporte.field_correo.yml
+++ b/config/sync/field.field.node.reporte.field_correo.yml
@@ -1,0 +1,19 @@
+uuid: 42d0cb44-f321-4db5-bd9c-b28351da88ac
+langcode: es
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_correo
+    - node.type.reporte
+id: node.reporte.field_correo
+field_name: field_correo
+entity_type: node
+bundle: reporte
+label: 'Correo electrónico'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: email

--- a/config/sync/field.field.node.reporte.field_latitud.yml
+++ b/config/sync/field.field.node.reporte.field_latitud.yml
@@ -1,0 +1,23 @@
+uuid: 0b9c22a7-7dcb-4084-b10b-1a2d3db3c211
+langcode: es
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_latitud
+    - node.type.reporte
+id: node.reporte.field_latitud
+field_name: field_latitud
+entity_type: node
+bundle: reporte
+label: Latitud
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: null
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: float

--- a/config/sync/field.field.node.reporte.field_longitud.yml
+++ b/config/sync/field.field.node.reporte.field_longitud.yml
@@ -1,0 +1,23 @@
+uuid: 2a0f603e-c73e-495d-8afc-c1a7932ac4cf
+langcode: es
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_longitud
+    - node.type.reporte
+id: node.reporte.field_longitud
+field_name: field_longitud
+entity_type: node
+bundle: reporte
+label: Longitud
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: null
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: float

--- a/config/sync/field.field.node.reporte.field_lugar.yml
+++ b/config/sync/field.field.node.reporte.field_lugar.yml
@@ -1,0 +1,19 @@
+uuid: 9b3f61e7-5db4-4b56-95be-8aecf4dc8772
+langcode: es
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_lugar
+    - node.type.reporte
+id: node.reporte.field_lugar
+field_name: field_lugar
+entity_type: node
+bundle: reporte
+label: Lugar
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/sync/field.field.node.reporte.field_solicita_asesoria_o_apoyo.yml
+++ b/config/sync/field.field.node.reporte.field_solicita_asesoria_o_apoyo.yml
@@ -1,0 +1,21 @@
+uuid: 443bb756-a8a4-4cb4-867a-1bf630d5be3d
+langcode: es
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_solicita_asesoria_o_apoyo
+    - node.type.reporte
+  module:
+    - options
+id: node.reporte.field_solicita_asesoria_o_apoyo
+field_name: field_solicita_asesoria_o_apoyo
+entity_type: node
+bundle: reporte
+label: 'Solicita asesoría o apoyo'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.field.node.reporte.field_subcategoria_reporte.yml
+++ b/config/sync/field.field.node.reporte.field_subcategoria_reporte.yml
@@ -1,0 +1,29 @@
+uuid: 8988e8a5-639f-4e4f-9344-96a1b92dde1d
+langcode: es
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_subcategoria_reporte
+    - node.type.reporte
+    - taxonomy.vocabulary.subcategorias_de_reporte
+id: node.reporte.field_subcategoria_reporte
+field_name: field_subcategoria_reporte
+entity_type: node
+bundle: reporte
+label: Subcategoría
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      subcategorias_de_reporte: subcategorias_de_reporte
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/config/sync/field.storage.node.field_categoria_reporte.yml
+++ b/config/sync/field.storage.node.field_categoria_reporte.yml
@@ -1,0 +1,20 @@
+uuid: 6ef9de86-cecc-4b30-894d-e4ddb2ba2310
+langcode: es
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_categoria_reporte
+field_name: field_categoria_reporte
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_latitud.yml
+++ b/config/sync/field.storage.node.field_latitud.yml
@@ -1,0 +1,18 @@
+uuid: d5a2ba4b-e4b0-45b8-ba7d-bcb6ff4598ee
+langcode: es
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_latitud
+field_name: field_latitud
+entity_type: node
+type: float
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_longitud.yml
+++ b/config/sync/field.storage.node.field_longitud.yml
@@ -1,0 +1,18 @@
+uuid: 3d0573d3-27bf-4947-a944-3a62271d475b
+langcode: es
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_longitud
+field_name: field_longitud
+entity_type: node
+type: float
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_lugar.yml
+++ b/config/sync/field.storage.node.field_lugar.yml
@@ -1,0 +1,19 @@
+uuid: fa018d1b-28b6-4610-af1f-7d0cbf36962a
+langcode: es
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_lugar
+field_name: field_lugar
+entity_type: node
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_solicita_asesoria_o_apoyo.yml
+++ b/config/sync/field.storage.node.field_solicita_asesoria_o_apoyo.yml
@@ -1,0 +1,27 @@
+uuid: 7da85ef3-5ffe-4996-8dba-096022441284
+langcode: es
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.field_solicita_asesoria_o_apoyo
+field_name: field_solicita_asesoria_o_apoyo
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: si
+      label: Sí
+    -
+      value: 'no'
+      label: 'No'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_subcategoria_reporte.yml
+++ b/config/sync/field.storage.node.field_subcategoria_reporte.yml
@@ -1,0 +1,20 @@
+uuid: ab7a45df-b588-44de-bce6-c60f9301dd9e
+langcode: es
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_subcategoria_reporte
+field_name: field_subcategoria_reporte
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/language.content_settings.node.reporte.yml
+++ b/config/sync/language.content_settings.node.reporte.yml
@@ -1,0 +1,11 @@
+uuid: 06452afd-d263-4823-8195-a5d3031f9878
+langcode: es
+status: true
+dependencies:
+  config:
+    - node.type.reporte
+id: node.reporte
+target_entity_type_id: node
+target_bundle: reporte
+default_langcode: site_default
+language_alterable: false

--- a/config/sync/language.content_settings.taxonomy_term.categorias_de_reporte.yml
+++ b/config/sync/language.content_settings.taxonomy_term.categorias_de_reporte.yml
@@ -1,0 +1,11 @@
+uuid: 68aebc6e-8ec8-498e-9bd2-f642f595afc5
+langcode: es
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.categorias_de_reporte
+id: taxonomy_term.categorias_de_reporte
+target_entity_type_id: taxonomy_term
+target_bundle: categorias_de_reporte
+default_langcode: site_default
+language_alterable: false

--- a/config/sync/language.content_settings.taxonomy_term.subcategorias_de_reporte.yml
+++ b/config/sync/language.content_settings.taxonomy_term.subcategorias_de_reporte.yml
@@ -1,0 +1,11 @@
+uuid: fb0408c8-efda-4671-916e-4aedfaaccffc
+langcode: es
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.subcategorias_de_reporte
+id: taxonomy_term.subcategorias_de_reporte
+target_entity_type_id: taxonomy_term
+target_bundle: subcategorias_de_reporte
+default_langcode: site_default
+language_alterable: false

--- a/config/sync/node.type.reporte.yml
+++ b/config/sync/node.type.reporte.yml
@@ -1,0 +1,17 @@
+uuid: c3deb14f-dbcc-429e-a518-34986f7f815d
+langcode: es
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus: {  }
+    parent: ''
+name: Reporte
+type: reporte
+description: ''
+help: ''
+new_revision: false
+preview_mode: 1
+display_submitted: false

--- a/config/sync/taxonomy.vocabulary.categorias_de_reporte.yml
+++ b/config/sync/taxonomy.vocabulary.categorias_de_reporte.yml
@@ -1,0 +1,9 @@
+uuid: 2dcc2434-d2c8-41f8-8af1-f97068f676e7
+langcode: es
+status: true
+dependencies: {  }
+name: 'Categorías de reporte'
+vid: categorias_de_reporte
+description: ''
+hierarchy: 0
+weight: 0

--- a/config/sync/taxonomy.vocabulary.subcategorias_de_reporte.yml
+++ b/config/sync/taxonomy.vocabulary.subcategorias_de_reporte.yml
@@ -1,0 +1,9 @@
+uuid: 8841cfd2-0788-4b1d-9b84-1edac51b8de9
+langcode: es
+status: true
+dependencies: {  }
+name: 'Subcategorías de reporte'
+vid: subcategorias_de_reporte
+description: ''
+hierarchy: 0
+weight: 0

--- a/config/sync/user.role.administrador_de_contenido.yml
+++ b/config/sync/user.role.administrador_de_contenido.yml
@@ -21,6 +21,7 @@ permissions:
   - 'delete any directorio content'
   - 'delete any espacio_libre_de_discriminacion content'
   - 'delete any recurso_juridico content'
+  - 'delete any reporte content'
   - 'edit any bloque_de_contenido content'
   - 'edit any derecho content'
   - 'edit any directorio content'

--- a/config/sync/views.view.reportes.yml
+++ b/config/sync/views.view.reportes.yml
@@ -1,0 +1,632 @@
+uuid: c2291a96-0739-42e0-bb40-d06bcc6ba8b5
+langcode: es
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_categoria_reporte
+    - field.storage.node.field_codigo_de_seguimient
+    - field.storage.node.field_subcategoria_reporte
+    - node.type.reporte
+    - taxonomy.vocabulary.categorias_de_reporte
+    - taxonomy.vocabulary.subcategorias_de_reporte
+  module:
+    - node
+    - taxonomy
+    - user
+id: reportes
+label: Reportes
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'See admin list pages'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: mini
+        options:
+          items_per_page: 10
+          offset: 0
+          id: 0
+          total_pages: null
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          tags:
+            previous: ‹‹
+            next: ››
+      style:
+        type: table
+      row:
+        type: fields
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Nombre
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+        field_categoria_reporte:
+          id: field_categoria_reporte
+          table: node__field_categoria_reporte
+          field: field_categoria_reporte
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Categoría
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_subcategoria_reporte:
+          id: field_subcategoria_reporte
+          table: node__field_subcategoria_reporte
+          field: field_subcategoria_reporte
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Subcategoría
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_codigo_de_seguimient:
+          id: field_codigo_de_seguimient
+          table: node__field_codigo_de_seguimient
+          field: field_codigo_de_seguimient
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Código de seguimiento'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        delete_node:
+          id: delete_node
+          table: node
+          field: delete_node
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Borrar
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: Borrar
+          entity_type: node
+          plugin_id: entity_link_delete
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          value:
+            reporte: reporte
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: title_op
+            label: Nombre
+            description: ''
+            use_operator: false
+            operator: title_op
+            identifier: title
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrador_de_contenido: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: title
+          plugin_id: string
+        field_categoria_reporte_target_id:
+          id: field_categoria_reporte_target_id
+          table: node__field_categoria_reporte
+          field: field_categoria_reporte_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_categoria_reporte_target_id_op
+            label: Categoría
+            description: ''
+            use_operator: false
+            operator: field_categoria_reporte_target_id_op
+            identifier: field_categoria_reporte_target_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrador_de_contenido: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: categorias_de_reporte
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+        field_subcategoria_reporte_target_id:
+          id: field_subcategoria_reporte_target_id
+          table: node__field_subcategoria_reporte
+          field: field_subcategoria_reporte_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_subcategoria_reporte_target_id_op
+            label: Subcategoría
+            description: ''
+            use_operator: false
+            operator: field_subcategoria_reporte_target_id_op
+            identifier: field_subcategoria_reporte_target_id
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrador_de_contenido: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          type: select
+          limit: true
+          vid: subcategorias_de_reporte
+          hierarchy: false
+          error_message: true
+          plugin_id: taxonomy_index_tid
+        field_codigo_de_seguimient_value:
+          id: field_codigo_de_seguimient_value
+          table: node__field_codigo_de_seguimient
+          field: field_codigo_de_seguimient_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_codigo_de_seguimient_value_op
+            label: 'Código de seguimiento'
+            description: ''
+            use_operator: false
+            operator: field_codigo_de_seguimient_value_op
+            identifier: field_codigo_de_seguimient_value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrador_de_contenido: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: string
+      sorts:
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          order: DESC
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exposed: false
+          expose:
+            label: ''
+          granularity: second
+      title: Reportes
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_categoria_reporte'
+        - 'config:field.storage.node.field_codigo_de_seguimient'
+        - 'config:field.storage.node.field_subcategoria_reporte'
+  page_1:
+    display_plugin: page
+    id: page_1
+    display_title: Reportes
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/fdi/reportes
+      display_description: ''
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_categoria_reporte'
+        - 'config:field.storage.node.field_codigo_de_seguimient'
+        - 'config:field.storage.node.field_subcategoria_reporte'

--- a/modules/custom/fdi_default_content/src/Plugin/GraphQL/InputTypes/ReporteInput.php
+++ b/modules/custom/fdi_default_content/src/Plugin/GraphQL/InputTypes/ReporteInput.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * @file
+ * Defines a mutation to create a node reporte.
+ */
+
+namespace Drupal\fdi_default_content\Plugin\GraphQL\InputTypes;
+
+use Drupal\graphql\Plugin\GraphQL\InputTypes\InputTypePluginBase;
+
+/**
+ * The input type for Contacto mutations.
+ *
+ * @GraphQLInputType(
+ *   id = "reporte_input",
+ *   name = "ReporteInput",
+ *   fields = {
+ *     "title" = "String",
+ *     "field_correo" = {
+ *        "type" = "String",
+ *        "nullable" = "TRUE"
+ *     },
+ *     "field_categoria_reporte" = {
+ *        "type" = "[Int]",
+ *        "nullable" = "TRUE"
+ *     },
+ *     "field_subcategoria_reporte" = {
+ *        "type" = "[Int]",
+ *        "nullable" = "TRUE"
+ *     },
+ *     "body" = {
+ *        "type" = "String",
+ *        "nullable" = "TRUE"
+ *     },
+ *     "field_codigo_de_seguimient" = {
+ *        "type" = "String",
+ *        "nullable" = "TRUE"
+ *     },
+ *     "field_latitud" = {
+ *        "type" = "Float",
+ *        "nullable" = "TRUE"
+ *     },
+ *     "field_longitud" = {
+ *        "type" = "Float",
+ *        "nullable" = "TRUE"
+ *     },
+ *     "field_lugar" = {
+ *        "type" = "String",
+ *        "nullable" = "TRUE"
+ *     },
+ *     "field_solicita_asesoria_o_apoyo" = {
+ *        "type" = "String",
+ *        "nullable" = "TRUE"
+ *     }
+ *   }
+ * )
+ */
+class ReporteInput extends InputTypePluginBase {
+
+}

--- a/modules/custom/fdi_default_content/src/Plugin/GraphQL/Mutations/CreateReporte.php
+++ b/modules/custom/fdi_default_content/src/Plugin/GraphQL/Mutations/CreateReporte.php
@@ -33,7 +33,7 @@ class CreateReporte extends CreateEntityBase {
     $codigo_seguimiento = 0;
     $result = 1;
     do {
-      $codigo_seguimiento = substr(md5(uniqid(mt_rand(), true)), 0, 8);
+      $codigo_seguimiento = substr(md5(uniqid(mt_rand(), TRUE)), 0, 8);
       $query = \Drupal::service('entity.query')
         ->get('node')
         ->condition('type', 'reporte')

--- a/modules/custom/fdi_default_content/src/Plugin/GraphQL/Mutations/CreateReporte.php
+++ b/modules/custom/fdi_default_content/src/Plugin/GraphQL/Mutations/CreateReporte.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @file
+ * Defines a mutation to create a node reporte.
+ */
+
+namespace Drupal\fdi_default_content\Plugin\GraphQL\Mutations;
+
+use Drupal\graphql\GraphQL\Type\InputObjectType;
+use Drupal\graphql_core\Plugin\GraphQL\Mutations\Entity\CreateEntityBase;
+use Youshido\GraphQL\Execution\ResolveInfo;
+/**
+ * Simple mutation for creating a new contacto node.
+ *
+ * @GraphQLMutation(
+ *   id = "create_reporte",
+ *   entity_type = "node",
+ *   entity_bundle = "reporte",
+ *   secure = true,
+ *   name = "createReporte",
+ *   type = "EntityCrudOutput!",
+ *   arguments = {
+ *     "input" = "ReporteInput"
+ *   }
+ * )
+ */
+class CreateReporte extends CreateEntityBase {
+  /**
+   * {@inheritdoc}
+   */
+  protected function extractEntityInput(array $input_args, InputObjectType $input_type, ResolveInfo $info) {
+    return [
+      'title' => $input_args['title'],
+      'field_correo' => $input_args['field_correo'],
+      'body' => $input_args['body'],
+      'field_codigo_de_seguimient' => $input_args['field_codigo_de_seguimient'],
+      'field_categoria_reporte' => $input_args['field_categoria_reporte'],
+      'field_subcategoria_reporte' => $input_args['field_subcategoria_reporte'],
+      'field_latitud' => $input_args['field_latitud'],
+      'field_longitud' => $input_args['field_longitud'],
+      'field_solicita_asesoria_o_apoyo' => $input_args['field_solicita_asesoria_o_apoyo'],
+      'field_lugar' => $input_args['field_lugar'],
+    ];
+  }
+
+}

--- a/modules/custom/fdi_default_content/src/Plugin/GraphQL/Mutations/CreateReporte.php
+++ b/modules/custom/fdi_default_content/src/Plugin/GraphQL/Mutations/CreateReporte.php
@@ -30,11 +30,21 @@ class CreateReporte extends CreateEntityBase {
    * {@inheritdoc}
    */
   protected function extractEntityInput(array $input_args, InputObjectType $input_type, ResolveInfo $info) {
+    $codigo_seguimiento = 0;
+    $result = 1;
+    do {
+      $codigo_seguimiento = substr(md5(uniqid(mt_rand(), true)), 0, 8);
+      $query = \Drupal::service('entity.query')
+        ->get('node')
+        ->condition('type', 'reporte')
+        ->condition('field_codigo_de_seguimient', $codigo_seguimiento);
+      $result = $query->execute();
+    } while (count($result) > 0);
     return [
       'title' => $input_args['title'],
       'field_correo' => $input_args['field_correo'],
       'body' => $input_args['body'],
-      'field_codigo_de_seguimient' => $input_args['field_codigo_de_seguimient'],
+      'field_codigo_de_seguimient' => $codigo_seguimiento,
       'field_categoria_reporte' => $input_args['field_categoria_reporte'],
       'field_subcategoria_reporte' => $input_args['field_subcategoria_reporte'],
       'field_latitud' => $input_args['field_latitud'],


### PR DESCRIPTION
[FDI-33](https://manati.atlassian.net/browse/FDI-33)
-
**Steps to test**
- Run `ahoy drush cim -y && ahoy drush cr`
- The categories and subcategories were not defined so create some, and remember the id of each taxonomy term, you would need it when running the graphql query
- Go to http://fdi.docker/es/graphql/explorer and add the following query to create a reporte node:

Query: 
```
mutation ($input: ReporteInput!) {
  createReporte(input: $input) {
    entity {
      entityId
      fieldCodigoDeSeguimient
    }
    errors
    violations {
      message
    }
  }
}
```
Query variable:
Replace the numbers in `field_categoria_reporte` and `field_subcategoria_reporte` with the id's of the taxonomoy terms you just created
```
{
  "input": {
    "title": "Reporte ejemplo 1",
    "field_correo": "luke@gmail.com",
    "body": "Mensaje del reporte",
    "field_subcategoria_reporte": [19,20],
    "field_categoria_reporte": [22, 23, 24, 21],
    "field_latitud": 44234234234423423,
    "field_longitud": 34234234234423423,
    "field_solicita_asesoria_o_apoyo": "si",
    "field_lugar": "Lugar"
  }
}
```
- After running this query a the field código de seguimiento should be prompt as a response
- Go to http://fdi.docker/es/admin/fdi/reportes and check the page looks alright