### PR TITLE
Create field image for machote content type.

### DIFF
--- a/config/sync/core.entity_form_display.node.machote.default.yml
+++ b/config/sync/core.entity_form_display.node.machote.default.yml
@@ -5,10 +5,13 @@ dependencies:
   config:
     - field.field.node.machote.body
     - field.field.node.machote.field_como_utilizarlo
+    - field.field.node.machote.field_imagen
     - field.field.node.machote.field_machote
+    - image.style.thumbnail
     - node.type.machote
   module:
     - file
+    - image
     - text
 id: node.machote.default
 targetEntityType: node
@@ -33,6 +36,14 @@ content:
     third_party_settings: {  }
     type: text_textarea_with_summary
     region: content
+  field_imagen:
+    weight: 1
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+    type: image_image
+    region: content
   field_machote:
     weight: 4
     settings:
@@ -42,7 +53,7 @@ content:
     region: content
   title:
     type: string_textfield
-    weight: 1
+    weight: 0
     region: content
     settings:
       size: 60

--- a/config/sync/core.entity_view_display.node.machote.default.yml
+++ b/config/sync/core.entity_view_display.node.machote.default.yml
@@ -5,10 +5,12 @@ dependencies:
   config:
     - field.field.node.machote.body
     - field.field.node.machote.field_como_utilizarlo
+    - field.field.node.machote.field_imagen
     - field.field.node.machote.field_machote
     - node.type.machote
   module:
     - file
+    - image
     - text
     - user
 id: node.machote.default
@@ -29,6 +31,15 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: text_default
+    region: content
+  field_imagen:
+    weight: 104
+    label: above
+    settings:
+      image_style: ''
+      image_link: ''
+    third_party_settings: {  }
+    type: image
     region: content
   field_machote:
     weight: 103

--- a/config/sync/field.field.node.machote.field_imagen.yml
+++ b/config/sync/field.field.node.machote.field_imagen.yml
@@ -1,0 +1,38 @@
+uuid: 5aec34f0-69a7-4b01-93fb-6609fff63307
+langcode: es
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_imagen
+    - node.type.machote
+  module:
+    - image
+id: node.machote.field_imagen
+field_name: field_imagen
+entity_type: node
+bundle: machote
+label: Imagen
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: false
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image


### PR DESCRIPTION
- Run `ahoy drush cim -y && ahoy drush cr`
- Check the field image was created for correctly for the machote content type