### PR TITLE
Feature/fdi 54 add new field to contacto content type

### DIFF
--- a/config/sync/core.entity_form_display.node.contacto.default.yml
+++ b/config/sync/core.entity_form_display.node.contacto.default.yml
@@ -6,9 +6,14 @@ dependencies:
     - field.field.node.contacto.body
     - field.field.node.contacto.field_codigo_de_seguimient
     - field.field.node.contacto.field_correo
+    - field.field.node.contacto.field_motivo_de_contacto
+    - field.field.node.contacto.field_nombre_del_sitio
+    - field.field.node.contacto.field_otro_motivo
+    - field.field.node.contacto.field_sitio_web
     - field.field.node.contacto.field_telefono
     - node.type.contacto
   module:
+    - link
     - text
 id: node.contacto.default
 targetEntityType: node
@@ -17,7 +22,7 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 2
+    weight: 1
     settings:
       rows: 9
       summary_rows: 3
@@ -25,7 +30,7 @@ content:
     third_party_settings: {  }
     region: content
   field_codigo_de_seguimient:
-    weight: 5
+    weight: 4
     settings:
       size: 60
       placeholder: ''
@@ -33,15 +38,45 @@ content:
     type: string_textfield
     region: content
   field_correo:
-    weight: 3
+    weight: 2
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
     type: email_default
     region: content
+  field_motivo_de_contacto:
+    weight: 5
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  field_nombre_del_sitio:
+    weight: 6
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_otro_motivo:
+    weight: 7
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_sitio_web:
+    type: link_default
+    weight: 8
+    region: content
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
   field_telefono:
-    weight: 4
+    weight: 3
     settings:
       size: 60
       placeholder: ''
@@ -50,7 +85,7 @@ content:
     region: content
   title:
     type: string_textfield
-    weight: 1
+    weight: 0
     region: content
     settings:
       size: 60

--- a/config/sync/core.entity_view_display.node.contacto.default.yml
+++ b/config/sync/core.entity_view_display.node.contacto.default.yml
@@ -6,9 +6,15 @@ dependencies:
     - field.field.node.contacto.body
     - field.field.node.contacto.field_codigo_de_seguimient
     - field.field.node.contacto.field_correo
+    - field.field.node.contacto.field_motivo_de_contacto
+    - field.field.node.contacto.field_nombre_del_sitio
+    - field.field.node.contacto.field_otro_motivo
+    - field.field.node.contacto.field_sitio_web
     - field.field.node.contacto.field_telefono
     - node.type.contacto
   module:
+    - link
+    - options
     - text
     - user
 id: node.contacto.default
@@ -37,6 +43,41 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: basic_string
+    region: content
+  field_motivo_de_contacto:
+    weight: 4
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
+    region: content
+  field_nombre_del_sitio:
+    weight: 7
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_otro_motivo:
+    weight: 8
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_sitio_web:
+    weight: 9
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+    type: link
     region: content
   field_telefono:
     weight: 1

--- a/config/sync/core.entity_view_display.node.contacto.teaser.yml
+++ b/config/sync/core.entity_view_display.node.contacto.teaser.yml
@@ -26,4 +26,10 @@ content:
     weight: 100
     region: content
 hidden:
+  field_codigo_de_seguimient: true
+  field_correo: true
+  field_motivo_de_contacto: true
+  field_nombre_del_sitio: true
+  field_otro_motivo: true
+  field_telefono: true
   langcode: true

--- a/config/sync/field.field.node.contacto.field_motivo_de_contacto.yml
+++ b/config/sync/field.field.node.contacto.field_motivo_de_contacto.yml
@@ -1,0 +1,21 @@
+uuid: 14547f64-ef8b-4c42-af60-4a06e6746c4e
+langcode: es
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_motivo_de_contacto
+    - node.type.contacto
+  module:
+    - options
+id: node.contacto.field_motivo_de_contacto
+field_name: field_motivo_de_contacto
+entity_type: node
+bundle: contacto
+label: Motivo
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/config/sync/field.field.node.contacto.field_nombre_del_sitio.yml
+++ b/config/sync/field.field.node.contacto.field_nombre_del_sitio.yml
@@ -1,0 +1,19 @@
+uuid: 8e5107b0-f30a-4817-b2fc-f2b75faf7cce
+langcode: es
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_nombre_del_sitio
+    - node.type.contacto
+id: node.contacto.field_nombre_del_sitio
+field_name: field_nombre_del_sitio
+entity_type: node
+bundle: contacto
+label: 'Nombre del sitio'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.contacto.field_otro_motivo.yml
+++ b/config/sync/field.field.node.contacto.field_otro_motivo.yml
@@ -1,0 +1,19 @@
+uuid: f83e5aa6-fc33-47e6-84d1-7d749970063b
+langcode: es
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_otro_motivo
+    - node.type.contacto
+id: node.contacto.field_otro_motivo
+field_name: field_otro_motivo
+entity_type: node
+bundle: contacto
+label: 'Motivo de contacto'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/config/sync/field.field.node.contacto.field_sitio_web.yml
+++ b/config/sync/field.field.node.contacto.field_sitio_web.yml
@@ -1,0 +1,23 @@
+uuid: 0eb13f10-fb78-4d8f-bc57-6734b55e3f77
+langcode: es
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_sitio_web
+    - node.type.contacto
+  module:
+    - link
+id: node.contacto.field_sitio_web
+field_name: field_sitio_web
+entity_type: node
+bundle: contacto
+label: 'Sitio web'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 16
+  title: 0
+field_type: link

--- a/config/sync/field.storage.node.field_motivo_de_contacto.yml
+++ b/config/sync/field.storage.node.field_motivo_de_contacto.yml
@@ -1,0 +1,30 @@
+uuid: f60e2a71-cde3-47eb-abb0-1429dfb779d5
+langcode: es
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.field_motivo_de_contacto
+field_name: field_motivo_de_contacto
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: recomendar_espacio
+      label: 'Recomendar sitio libre de discriminación'
+    -
+      value: tengo_codigo
+      label: 'Tengo código de seguimiento'
+    -
+      value: otro
+      label: Otro
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_nombre_del_sitio.yml
+++ b/config/sync/field.storage.node.field_nombre_del_sitio.yml
@@ -1,0 +1,20 @@
+uuid: 72802846-a6e0-4c9f-ad7e-62af75a4e486
+langcode: es
+status: true
+dependencies:
+  module:
+    - node
+    - text
+id: node.field_nombre_del_sitio
+field_name: field_nombre_del_sitio
+entity_type: node
+type: text
+settings:
+  max_length: 255
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_otro_motivo.yml
+++ b/config/sync/field.storage.node.field_otro_motivo.yml
@@ -1,0 +1,21 @@
+uuid: 810d5a2e-d3ce-47a3-945d-bbaf939c9c2a
+langcode: es
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.field_otro_motivo
+field_name: field_otro_motivo
+entity_type: node
+type: list_string
+settings:
+  allowed_values: {  }
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/field.storage.node.field_sitio_web.yml
+++ b/config/sync/field.storage.node.field_sitio_web.yml
@@ -1,0 +1,19 @@
+uuid: 352f0393-2bd9-43d9-a7b4-432f9200893a
+langcode: es
+status: true
+dependencies:
+  module:
+    - link
+    - node
+id: node.field_sitio_web
+field_name: field_sitio_web
+entity_type: node
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/sync/views.view.contactos.yml
+++ b/config/sync/views.view.contactos.yml
@@ -5,9 +5,11 @@ dependencies:
   config:
     - field.storage.node.field_codigo_de_seguimient
     - field.storage.node.field_correo
+    - field.storage.node.field_motivo_de_contacto
     - node.type.contacto
   module:
     - node
+    - options
     - user
 id: contactos
 label: Contactos
@@ -262,6 +264,68 @@ display:
           separator: ', '
           field_api_classes: false
           plugin_id: field
+        field_motivo_de_contacto:
+          id: field_motivo_de_contacto
+          table: node__field_motivo_de_contacto
+          field: field_motivo_de_contacto
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Motivo
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: list_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
         delete_node:
           id: delete_node
           table: node
@@ -450,6 +514,46 @@ display:
             default_group_multiple: {  }
             group_items: {  }
           plugin_id: string
+        field_motivo_de_contacto_value:
+          id: field_motivo_de_contacto_value
+          table: node__field_motivo_de_contacto
+          field: field_motivo_de_contacto_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_motivo_de_contacto_value_op
+            label: Motivo
+            description: ''
+            use_operator: false
+            operator: field_motivo_de_contacto_value_op
+            identifier: field_motivo_de_contacto_value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrador_de_contenido: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          plugin_id: list_field
       sorts:
         created:
           id: created
@@ -474,7 +578,7 @@ display:
       arguments: {  }
       display_extenders: {  }
     cache_metadata:
-      max-age: 0
+      max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
@@ -485,6 +589,7 @@ display:
       tags:
         - 'config:field.storage.node.field_codigo_de_seguimient'
         - 'config:field.storage.node.field_correo'
+        - 'config:field.storage.node.field_motivo_de_contacto'
   page_1:
     display_plugin: page
     id: page_1
@@ -495,7 +600,7 @@ display:
       path: admin/fdi/contactos
       display_description: ''
     cache_metadata:
-      max-age: 0
+      max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
@@ -506,3 +611,4 @@ display:
       tags:
         - 'config:field.storage.node.field_codigo_de_seguimient'
         - 'config:field.storage.node.field_correo'
+        - 'config:field.storage.node.field_motivo_de_contacto'

--- a/modules/custom/fdi_default_content/fdi_default_content.module
+++ b/modules/custom/fdi_default_content/fdi_default_content.module
@@ -46,7 +46,6 @@ function fdi_default_content_form_alter(&$form, &$form_state, $form_id) {
  * Implements hook_mail().
  */
 function fdi_default_content_mail($key, &$message, $params) {
-
   switch ($key) {
     case 'insert_contacto_node':
       $message['from'] = \Drupal::config('system.site')->get('mail');
@@ -54,8 +53,37 @@ function fdi_default_content_mail($key, &$message, $params) {
       $message['body']['message_intro'] = $params['message_intro'];
       $message['body']['nombre'] = "Nombre:\n" . $params['entity']->get('title')->getValue()[0]['value'];
       $message['body']['email'] = "Correo electrónico:\n" . $params['entity']->get('field_correo')->getValue()[0]['value'];
-      $message['body']['telefono'] = "Teléfono:\n" . $params['entity']->get('field_telefono')->getValue()[0]['value'];
-      $message['body']['codigo'] = "Código de seguimiento:\n" . $params['entity']->get('field_codigo_de_seguimient')->getValue()[0]['value'];
+      // Field telefono.
+      if ($params['entity']->get('field_telefono')->getValue()[0]['value']) {
+        $message['body']['telefono'] = "Teléfono:\n" . $params['entity']->get('field_telefono')->getValue()[0]['value'];
+      }
+      // Field motivo de contacto.
+      if ($params['entity']->get('field_motivo_de_contacto')->getValue()[0]['value']) {
+        $message['body']['motivo_list'] = "Motivo del contacto:\n" . $params['entity']->get('field_motivo_de_contacto')
+          ->getFieldDefinition()
+          ->getFieldStorageDefinition()
+          ->getOptionsProvider(
+            'value',
+            $params['entity']->get('field_motivo_de_contacto')
+            ->getEntity())
+            ->getPossibleOptions()[$params['entity']->get('field_motivo_de_contacto')->value];
+      }
+      // Field nombre del sitio.
+      if ($params['entity']->get('field_nombre_del_sitio')->getValue()[0]['value']) {
+        $message['body']['nombre_del_sitio'] = "Nombre del sitio:\n" . $params['entity']->get('field_nombre_del_sitio')->getValue()[0]['value'];
+      }
+      // Field sitio web.
+      if ($params['entity']->get('field_sitio_web')->getValue()[0]['uri']) {
+        $message['body']['sitio_web'] = "Sitio Web:\n" . $params['entity']->get('field_sitio_web')->getValue()[0]['uri'];
+      }
+      // Field codigo.
+      if ($params['entity']->get('field_codigo_de_seguimient')->getValue()[0]['value']) {
+        $message['body']['codigo'] = "Código de seguimiento:\n" . $params['entity']->get('field_codigo_de_seguimient')->getValue()[0]['value'];
+      }
+      // Field otro motivo.
+      if ($params['entity']->get('field_otro_motivo')->getValue()[0]['value']) {
+        $message['body']['motivo'] = "Motivo:\n" . $params['entity']->get('field_otro_motivo')->getValue()[0]['value'];
+      }
       $message['body']['mensaje'] = MailFormatHelper::htmlToText("Mensaje:\n" . $params['entity']->get('body')->getValue()[0]['value']);
       break;
 

--- a/modules/custom/fdi_default_content/src/Plugin/GraphQL/InputTypes/ContactoInput.php
+++ b/modules/custom/fdi_default_content/src/Plugin/GraphQL/InputTypes/ContactoInput.php
@@ -29,6 +29,22 @@ use Drupal\graphql\Plugin\GraphQL\InputTypes\InputTypePluginBase;
  *        "type" = "String",
  *        "nullable" = "TRUE"
  *     },
+ *     "field_motivo_de_contacto" = {
+ *        "type" = "String",
+ *        "nullable" = "TRUE"
+ *     },
+ *     "field_otro_motivo" = {
+ *        "type" = "String",
+ *        "nullable" = "TRUE"
+ *     },
+ *     "field_nombre_del_sitio" = {
+ *        "type" = "String",
+ *        "nullable" = "TRUE"
+ *     },
+ *     "field_sitio_web" = {
+ *        "type" = "String",
+ *        "nullable" = "TRUE"
+ *     },
  *     "field_codigo_de_seguimient" = {
  *        "type" = "String",
  *        "nullable" = "TRUE"

--- a/modules/custom/fdi_default_content/src/Plugin/GraphQL/Mutations/CreateContacto.php
+++ b/modules/custom/fdi_default_content/src/Plugin/GraphQL/Mutations/CreateContacto.php
@@ -34,6 +34,10 @@ class CreateContacto extends CreateEntityBase {
       'field_correo' => $args['input']['field_correo'],
       'field_telefono' => $args['input']['field_telefono'],
       'body' => $args['input']['body'],
+      'field_sitio_web' => $args['input']['field_sitio_web'],
+      'field_nombre_del_sitio' => $args['input']['field_nombre_del_sitio'],
+      'field_otro_motivo' => $args['input']['field_otro_motivo'],
+      'field_motivo_de_contacto' => $args['input']['field_motivo_de_contacto'],
       'field_codigo_de_seguimient' => $args['input']['field_codigo_de_seguimient'],
     ];
   }


### PR DESCRIPTION
[FDI-54](https://manati.atlassian.net/browse/FDI-54)
-
- Get the mialhog url `ahoy docker mailhog-url`
- Run `ahoy drush cim -y && ahoy drush cr`
- Create contacto nodes, you should get an email, with the fields you filled. 
- Try to create a node using a mutation
- fields added: field_motivo_de_contacto, field_otro_motivo, field_nombre_del_sitio and field_sitio_web
query
```
mutation ($input: ContactoInput!) {
  createContacto(input: $input) {
    entity {
      entityId
    }
    errors
    violations {
      message
    }
  }
}
```
variable
```
{
  "input": {
    "title": "Luke Skywalker",
    "field_correo": "luke@gmail.com",
    "field_telefono": "44444444",
    "body": "May the force be with you",
    "field_motivo_de_contacto": "recomendar_espacio",
    "field_otro_motivo": "Este es el otro motivo",
    "field_nombre_del_sitio": "Nombre del sitio a sugerir",
    "field_sitio_web": "http://www.google.com",
    "field_codigo_de_seguimient": "frfrf834238d"
  }
}
```